### PR TITLE
feat(pi-agent): add composable prompt guidance and workflow accelerators

### DIFF
--- a/nix/home/pi.nix
+++ b/nix/home/pi.nix
@@ -41,4 +41,9 @@
     source = ../../pi/agent/subagents;
     recursive = true;
   };
+
+  home.file.".pi/agent/system-fragments" = {
+    source = ../../pi/agent/system-fragments;
+    recursive = true;
+  };
 }

--- a/pi/agent/extensions/prompt-composer.ts
+++ b/pi/agent/extensions/prompt-composer.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type FragmentSelection = {
+  relativePath: string;
+  reason: string;
+};
+
+type Composition = {
+  cwd: string;
+  platform: NodeJS.Platform;
+  activeTools: string[];
+  selected: FragmentSelection[];
+  truncated: boolean;
+  injectedChars: number;
+};
+
+const MAX_INJECTED_CHARS = 12_000;
+const FRAGMENT_CACHE = new Map<string, string>();
+
+const extensionDir = path.dirname(fileURLToPath(import.meta.url));
+const fragmentsRoot = path.join(extensionDir, "..", "system-fragments");
+
+function hasAnyFile(cwd: string, names: string[]): boolean {
+  return names.some((name) => fs.existsSync(path.join(cwd, name)));
+}
+
+function detectLanguageFragments(cwd: string): FragmentSelection[] {
+  const selections: FragmentSelection[] = [];
+
+  if (hasAnyFile(cwd, ["package.json", "tsconfig.json"])) {
+    selections.push({
+      relativePath: "lang/typescript.md",
+      reason: "TypeScript/Node project signals detected",
+    });
+  }
+
+  if (hasAnyFile(cwd, ["Gemfile", ".ruby-version", "config/application.rb"])) {
+    selections.push({
+      relativePath: "lang/ruby.md",
+      reason: "Ruby/Rails project signals detected",
+    });
+  }
+
+  if (hasAnyFile(cwd, ["go.mod"])) {
+    selections.push({
+      relativePath: "lang/go.md",
+      reason: "Go module detected",
+    });
+  }
+
+  return selections;
+}
+
+function detectOsFragment(platform: NodeJS.Platform): FragmentSelection | undefined {
+  if (platform === "darwin") {
+    return { relativePath: "os/macos.md", reason: "Host platform is macOS" };
+  }
+
+  if (platform === "linux") {
+    return { relativePath: "os/linux.md", reason: "Host platform is Linux" };
+  }
+
+  if (platform === "win32") {
+    return { relativePath: "os/windows.md", reason: "Host platform is Windows" };
+  }
+
+  return undefined;
+}
+
+function detectReadOnlyMode(activeTools: string[]): boolean {
+  if (activeTools.length === 0) return false;
+  const names = new Set(activeTools);
+  return !names.has("edit") && !names.has("write");
+}
+
+function collectSelections(cwd: string, platform: NodeJS.Platform, activeTools: string[]): FragmentSelection[] {
+  const selections: FragmentSelection[] = [
+    {
+      relativePath: "base/core.md",
+      reason: "Always-on coding workflow guidance",
+    },
+    {
+      relativePath: "base/tool-usage.md",
+      reason: "Always-on tool selection policy",
+    },
+    {
+      relativePath: "base/safety.md",
+      reason: "Always-on safety and confirmation guidance",
+    },
+  ];
+
+  const osFragment = detectOsFragment(platform);
+  if (osFragment) selections.push(osFragment);
+
+  if (fs.existsSync(path.join(cwd, ".git"))) {
+    selections.push({
+      relativePath: "repo/worktree.md",
+      reason: "Repository context detected",
+    });
+  }
+
+  if (detectReadOnlyMode(activeTools)) {
+    selections.push({
+      relativePath: "mode/read-only.md",
+      reason: "Active tools indicate read-only/planning mode",
+    });
+  }
+
+  selections.push(...detectLanguageFragments(cwd));
+
+  return selections;
+}
+
+async function loadFragment(relativePath: string): Promise<string | undefined> {
+  if (FRAGMENT_CACHE.has(relativePath)) {
+    return FRAGMENT_CACHE.get(relativePath);
+  }
+
+  const fullPath = path.join(fragmentsRoot, relativePath);
+  try {
+    const content = await fs.promises.readFile(fullPath, "utf8");
+    const normalized = content.trim();
+    FRAGMENT_CACHE.set(relativePath, normalized);
+    return normalized;
+  } catch {
+    return undefined;
+  }
+}
+
+async function composeRuntimePrompt(cwd: string, platform: NodeJS.Platform, activeTools: string[]): Promise<{
+  text: string;
+  composition: Composition;
+}> {
+  const selections = collectSelections(cwd, platform, activeTools);
+  const blocks: string[] = [];
+  let currentChars = 0;
+  let truncated = false;
+
+  for (const selection of selections) {
+    const fragment = await loadFragment(selection.relativePath);
+    if (!fragment) continue;
+
+    const block = `### ${selection.relativePath}\n${fragment}`;
+    const nextChars = currentChars + block.length;
+
+    if (nextChars > MAX_INJECTED_CHARS) {
+      truncated = true;
+      break;
+    }
+
+    blocks.push(block);
+    currentChars = nextChars;
+  }
+
+  const intro = "## Runtime guidance (composed)";
+  const body = blocks.join("\n\n");
+  const truncationNote = truncated
+    ? "\n\n_Note: additional fragments were available but omitted to control prompt size._"
+    : "";
+
+  const text = blocks.length > 0 ? `${intro}\n\n${body}${truncationNote}` : "";
+
+  return {
+    text,
+    composition: {
+      cwd,
+      platform,
+      activeTools,
+      selected: selections,
+      truncated,
+      injectedChars: currentChars,
+    },
+  };
+}
+
+export default function promptComposer(pi: ExtensionAPI) {
+  let lastComposition: Composition | null = null;
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    const activeTools = pi.getActiveTools();
+    const result = await composeRuntimePrompt(ctx.cwd, process.platform, activeTools);
+    lastComposition = result.composition;
+
+    if (!result.text) {
+      return;
+    }
+
+    return {
+      systemPrompt: `${event.systemPrompt}\n\n${result.text}`,
+    };
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (!ctx.hasUI) return;
+    if (!lastComposition) return;
+
+    ctx.ui.setStatus(
+      "prompt-composer",
+      `prompt-composer: ${lastComposition.selected.length} fragments (${lastComposition.injectedChars} chars)`
+    );
+  });
+}

--- a/pi/agent/extensions/prompt-composer.ts
+++ b/pi/agent/extensions/prompt-composer.ts
@@ -13,6 +13,7 @@ type Composition = {
   platform: NodeJS.Platform;
   activeTools: string[];
   selected: FragmentSelection[];
+  consideredCount: number;
   truncated: boolean;
   injectedChars: number;
 };
@@ -130,20 +131,34 @@ async function loadFragment(relativePath: string): Promise<string | undefined> {
   }
 }
 
+function formatCompositionSummary(composition: Composition): string[] {
+  return [
+    `cwd: ${composition.cwd}`,
+    `platform: ${composition.platform}`,
+    `active tools: ${composition.activeTools.join(", ") || "(none)"}`,
+    `fragments considered: ${composition.consideredCount}`,
+    `fragments injected: ${composition.selected.length}`,
+    `prompt chars injected: ${composition.injectedChars}`,
+    `truncated: ${composition.truncated ? "yes" : "no"}`,
+  ];
+}
+
 async function composeRuntimePrompt(cwd: string, platform: NodeJS.Platform, activeTools: string[]): Promise<{
   text: string;
   composition: Composition;
 }> {
-  const selections = collectSelections(cwd, platform, activeTools);
+  const considered = collectSelections(cwd, platform, activeTools);
+  const selected: FragmentSelection[] = [];
   const blocks: string[] = [];
+
   let currentChars = 0;
   let truncated = false;
 
-  for (const selection of selections) {
-    const fragment = await loadFragment(selection.relativePath);
+  for (const candidate of considered) {
+    const fragment = await loadFragment(candidate.relativePath);
     if (!fragment) continue;
 
-    const block = `### ${selection.relativePath}\n${fragment}`;
+    const block = `### ${candidate.relativePath}\n${fragment}`;
     const nextChars = currentChars + block.length;
 
     if (nextChars > MAX_INJECTED_CHARS) {
@@ -152,6 +167,7 @@ async function composeRuntimePrompt(cwd: string, platform: NodeJS.Platform, acti
     }
 
     blocks.push(block);
+    selected.push(candidate);
     currentChars = nextChars;
   }
 
@@ -169,7 +185,8 @@ async function composeRuntimePrompt(cwd: string, platform: NodeJS.Platform, acti
       cwd,
       platform,
       activeTools,
-      selected: selections,
+      selected,
+      consideredCount: considered.length,
       truncated,
       injectedChars: currentChars,
     },
@@ -179,10 +196,45 @@ async function composeRuntimePrompt(cwd: string, platform: NodeJS.Platform, acti
 export default function promptComposer(pi: ExtensionAPI) {
   let lastComposition: Composition | null = null;
 
+  pi.registerCommand("prompt-debug", {
+    description: "Show active prompt-composer fragments for the current repo/tool mode",
+    handler: async (args, ctx) => {
+      if (!ctx.hasUI) return;
+      if (!lastComposition) {
+        ctx.ui.notify("prompt-composer: no composition has been generated yet in this session.", "warning");
+        return;
+      }
+
+      const showFull = (args ?? "").trim().toLowerCase() === "full";
+      const lines = ["prompt-composer", ...formatCompositionSummary(lastComposition), "", "selected fragments:"];
+
+      if (lastComposition.selected.length === 0) {
+        lines.push("- (none)");
+      } else {
+        for (const selection of lastComposition.selected) {
+          lines.push(`- ${selection.relativePath}: ${selection.reason}`);
+          if (showFull) {
+            const content = FRAGMENT_CACHE.get(selection.relativePath) ?? "(not loaded)";
+            lines.push(`  ${content.replace(/\n/g, "\n  ")}`);
+          }
+        }
+      }
+
+      ctx.ui.notify(lines.join("\n"), "info");
+    },
+  });
+
   pi.on("before_agent_start", async (event, ctx) => {
     const activeTools = pi.getActiveTools();
     const result = await composeRuntimePrompt(ctx.cwd, process.platform, activeTools);
     lastComposition = result.composition;
+
+    if (ctx.hasUI) {
+      ctx.ui.setStatus(
+        "prompt-composer",
+        `prompt: ${result.composition.selected.length}/${result.composition.consideredCount} fragments`
+      );
+    }
 
     if (!result.text) {
       return;
@@ -191,15 +243,5 @@ export default function promptComposer(pi: ExtensionAPI) {
     return {
       systemPrompt: `${event.systemPrompt}\n\n${result.text}`,
     };
-  });
-
-  pi.on("session_start", async (_event, ctx) => {
-    if (!ctx.hasUI) return;
-    if (!lastComposition) return;
-
-    ctx.ui.setStatus(
-      "prompt-composer",
-      `prompt-composer: ${lastComposition.selected.length} fragments (${lastComposition.injectedChars} chars)`
-    );
   });
 }

--- a/pi/agent/extensions/runtime-reminders.ts
+++ b/pi/agent/extensions/runtime-reminders.ts
@@ -1,0 +1,132 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const COMPLEX_PROMPT_KEYWORDS = [
+  "implement",
+  "investigate",
+  "refactor",
+  "migrate",
+  "design",
+  "architecture",
+  "plan",
+  "workflow",
+  "multi-step",
+  "orchestrat",
+];
+
+function extractToolResultText(event: any): string {
+  if (!Array.isArray(event.content)) return "";
+
+  return event.content
+    .filter((item: any) => item?.type === "text" && typeof item.text === "string")
+    .map((item: any) => item.text)
+    .join("\n")
+    .toLowerCase();
+}
+
+function looksLikePermissionDenial(text: string): boolean {
+  return /(permission|denied|not allowed|approval|blocked by user|cancelled by user)/i.test(text);
+}
+
+function looksLikeEditDrift(text: string): boolean {
+  return /(old_string|old text|not found|not unique|failed to match exact)/i.test(text);
+}
+
+function isComplexPrompt(prompt: string): boolean {
+  const lower = prompt.toLowerCase();
+  if (lower.length > 180) return true;
+  return COMPLEX_PROMPT_KEYWORDS.some((keyword) => lower.includes(keyword));
+}
+
+function isDelegationTool(toolName: string): boolean {
+  return toolName === "subagent" || toolName === "subagent_list";
+}
+
+export default function runtimeReminders(pi: ExtensionAPI) {
+  let turnCount = 0;
+  let delegatedThisTurn = false;
+  let turnsWithoutDelegation = 0;
+
+  let pendingPermissionReminder = false;
+  let pendingEditDriftReminder = false;
+
+  let lastDelegationReminderTurn = -100;
+  let lastContextReminderTurn = -100;
+
+  pi.on("turn_start", async () => {
+    delegatedThisTurn = false;
+  });
+
+  pi.on("tool_call", async (event) => {
+    if (isDelegationTool(event.toolName)) {
+      delegatedThisTurn = true;
+    }
+  });
+
+  pi.on("tool_result", async (event) => {
+    if (!event.isError) return;
+
+    const text = extractToolResultText(event);
+    if (!text) return;
+
+    if (looksLikePermissionDenial(text)) {
+      pendingPermissionReminder = true;
+    }
+
+    if (event.toolName === "edit" && looksLikeEditDrift(text)) {
+      pendingEditDriftReminder = true;
+    }
+  });
+
+  pi.on("turn_end", async () => {
+    turnCount += 1;
+    turnsWithoutDelegation = delegatedThisTurn ? 0 : turnsWithoutDelegation + 1;
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    const reminders: string[] = [];
+
+    if (pendingPermissionReminder) {
+      reminders.push(
+        "A recent tool call appears to have been denied. Do not retry the exact same call; adapt your approach or ask the user for clarification."
+      );
+      pendingPermissionReminder = false;
+    }
+
+    if (pendingEditDriftReminder) {
+      reminders.push(
+        "A recent edit likely failed due to stale context. Re-read the target file/section before attempting another edit."
+      );
+      pendingEditDriftReminder = false;
+    }
+
+    if (
+      turnsWithoutDelegation >= 3 &&
+      isComplexPrompt(event.prompt) &&
+      turnCount - lastDelegationReminderTurn >= 3
+    ) {
+      reminders.push(
+        "This looks like complex, multi-step work. Consider using subagent_list and subagent delegation for deeper exploration or parallelized analysis."
+      );
+      lastDelegationReminderTurn = turnCount;
+    }
+
+    const usage = ctx.getContextUsage();
+    if (usage && usage.percent >= 85 && turnCount - lastContextReminderTurn >= 2) {
+      reminders.push(
+        `Context usage is high (${usage.percent.toFixed(1)}%). Keep responses focused and consider compaction if context pressure increases.`
+      );
+      lastContextReminderTurn = turnCount;
+    }
+
+    if (reminders.length === 0) return;
+
+    const reminderText = [
+      "## Runtime reminders",
+      ...reminders.map((line) => `- ${line}`),
+    ].join("\n");
+
+    return {
+      systemPrompt: `${event.systemPrompt}\n\n${reminderText}`,
+    };
+  });
+}

--- a/pi/agent/prompts/quick-commit.md
+++ b/pi/agent/prompts/quick-commit.md
@@ -1,0 +1,17 @@
+---
+description: Create a single high-signal commit from current changes
+---
+Create one commit for the current changes.
+
+Workflow:
+1. Inspect repo state (`git status --short`, `git diff --cached`, then `git diff` if needed).
+2. Draft a conventional commit message (subject + body) that explains why.
+3. Ask for confirmation of the message and staged file scope.
+4. Delegate all git operations to the `git-ops` subagent (stage, verify staged diff, commit).
+5. Return commit hash, final branch, and post-commit status.
+
+Constraints:
+- Stage only intended files.
+- Never amend unless explicitly requested.
+- Never skip hooks unless explicitly requested.
+- If there is nothing to commit, report it clearly and stop.

--- a/pi/agent/prompts/quick-pr.md
+++ b/pi/agent/prompts/quick-pr.md
@@ -1,0 +1,21 @@
+---
+description: Prepare changes and open/update a pull request safely
+---
+Prepare and publish the current work as a pull request.
+
+Workflow:
+1. Inspect branch/diff scope versus default branch and summarize what will ship.
+2. Confirm branch/worktree safety (avoid main worktree for feature work).
+3. Run or suggest relevant validation checks before publishing.
+4. Delegate all git operations to `git-ops` (staging, commit creation, push).
+5. Ask for confirmation before any network-visible action (push/PR create/edit).
+6. Create or update the PR with:
+   - short title
+   - concise summary bullets
+   - test/verification checklist
+7. Return PR URL and a short summary of what was published.
+
+Constraints:
+- Keep commit/PR scope tight and intentional.
+- Do not force push unless explicitly requested.
+- Do not include secrets or unrelated files.

--- a/pi/agent/prompts/security-review.md
+++ b/pi/agent/prompts/security-review.md
@@ -1,0 +1,23 @@
+---
+description: Perform a focused, high-confidence security review of current diff
+---
+Perform a security-focused review of the current change set.
+
+Workflow:
+1. Review `git diff --cached`; if empty, review `git diff`.
+2. Focus on high-confidence issues only:
+   - injection risks (SQL/command/template/path)
+   - authz/authn bypasses
+   - unsafe secret handling/logging
+   - trust-boundary validation failures
+3. Ignore speculative or low-impact noise.
+4. Provide a markdown report with:
+   - severity
+   - file/path
+   - vulnerable behavior
+   - exploit path
+   - concrete fix
+5. If no meaningful findings, explicitly state that with confidence caveats.
+
+Optional:
+- For broader coverage, delegate to `reviewer` and `testing-reviewer` in parallel, then synthesize.

--- a/pi/agent/subagents/architect.md
+++ b/pi/agent/subagents/architect.md
@@ -18,6 +18,12 @@ Success looks like:
 - Solutions that minimize overall system complexity without sacrificing module cohesion
 - Actionable next steps with clear implementation guidance
 
+## Operating Constraints
+
+- This role is read-only design analysis; do not mutate repository state.
+- Ground recommendations in observed code patterns and cite concrete files.
+- Separate confirmed facts from assumptions or hypotheses.
+
 # Architecture Design Philosophy
 
 ## Systems Thinking First

--- a/pi/agent/subagents/code-explorer.md
+++ b/pi/agent/subagents/code-explorer.md
@@ -18,6 +18,13 @@ Success looks like:
 - Context-rich findings that enable expert-level understanding
 - Identification of knowledge gaps and areas requiring additional exploration
 
+# Operating Constraints
+
+- Treat this role as read-only research: do not perform mutating operations in the repo.
+- Use bash only for exploration (search, listing, read-only git history/metadata).
+- Return file paths as absolute paths in final findings whenever possible.
+- Explicitly call out uncertainty instead of inferring beyond available evidence.
+
 # Multi-Source Research Tools
 
 ## Code Analysis

--- a/pi/agent/subagents/planner.md
+++ b/pi/agent/subagents/planner.md
@@ -10,13 +10,16 @@ Primary goal:
 - Turn a scoped request into a practical implementation plan the parent agent can execute.
 
 Rules:
+- This is a planning-only role. Do not execute mutating actions or propose speculative edits without evidence.
 - Start with assumptions and constraints.
 - Break work into incremental milestones.
 - Include validation strategy and rollback considerations.
 - Keep recommendations aligned with the current repository context.
+- Prefer reuse of existing patterns/utilities over introducing new abstractions.
 
 Output format:
 1. Assumptions/constraints
 2. Plan (numbered milestones)
 3. Risks and mitigations
 4. Validation checklist
+5. Critical files (3-5 paths with one-line reason each)

--- a/pi/agent/system-fragments/base/core.md
+++ b/pi/agent/system-fragments/base/core.md
@@ -1,0 +1,4 @@
+- Keep changes small, reversible, and directly tied to user intent.
+- Read before editing and preserve existing local style/conventions.
+- Avoid speculative refactors or opportunistic cleanups unless explicitly requested.
+- When uncertain, investigate first; do not guess.

--- a/pi/agent/system-fragments/base/safety.md
+++ b/pi/agent/system-fragments/base/safety.md
@@ -1,0 +1,4 @@
+- Confirm before destructive or hard-to-reverse actions.
+- Do not treat one prior approval as blanket approval for future risky operations.
+- If permissions are denied, adapt approach or ask for clarification instead of retrying identically.
+- Prefer root-cause fixes over bypass flags or safety-check circumvention.

--- a/pi/agent/system-fragments/base/tool-usage.md
+++ b/pi/agent/system-fragments/base/tool-usage.md
@@ -1,0 +1,4 @@
+- Prefer dedicated tools for file operations over shell command workarounds.
+- Use parallel tool calls for independent reads/searches to reduce latency.
+- Sequence dependent operations explicitly; do not use placeholder arguments.
+- Communicate directly in assistant text, never via shell echo/printf.

--- a/pi/agent/system-fragments/lang/go.md
+++ b/pi/agent/system-fragments/lang/go.md
@@ -1,0 +1,4 @@
+- Follow idiomatic Go: clear package boundaries, explicit errors, and minimal magic.
+- Prefer straightforward functions and structs over unnecessary abstraction layers.
+- Keep formatting/tooling compatibility with gofmt/go test expectations.
+- Avoid introducing hidden control flow or reflection-heavy patterns without clear need.

--- a/pi/agent/system-fragments/lang/ruby.md
+++ b/pi/agent/system-fragments/lang/ruby.md
@@ -1,0 +1,4 @@
+- Follow existing Ruby/Rails conventions in naming, structure, and idioms.
+- Prefer small, intention-revealing methods over broad abstractions.
+- Keep behavior changes consistent with existing tests and callback/validation patterns.
+- Avoid incidental framework-wide rewrites for narrow feature requests.

--- a/pi/agent/system-fragments/lang/typescript.md
+++ b/pi/agent/system-fragments/lang/typescript.md
@@ -1,0 +1,4 @@
+- Preserve the repository's TypeScript style and tsconfig assumptions.
+- Prefer narrow, explicit types at boundaries and avoid broad `any` usage.
+- Keep runtime behavior changes paired with relevant tests or validation commands.
+- Avoid large type-system refactors unless they are directly required.

--- a/pi/agent/system-fragments/mode/read-only.md
+++ b/pi/agent/system-fragments/mode/read-only.md
@@ -1,0 +1,4 @@
+- You are currently in a read-only/planning-oriented toolset.
+- Do not attempt edits, writes, or irreversible system mutations.
+- Focus on exploration, constraints, alternatives, and actionable execution plans.
+- Clearly separate verified facts from assumptions.

--- a/pi/agent/system-fragments/os/linux.md
+++ b/pi/agent/system-fragments/os/linux.md
@@ -1,0 +1,3 @@
+- Assume GNU/Linux shell semantics and typical GNU coreutils behavior.
+- Quote paths with spaces and prefer absolute paths in shell commands.
+- Be mindful of case-sensitive file paths and permissions differences vs macOS/Windows.

--- a/pi/agent/system-fragments/os/macos.md
+++ b/pi/agent/system-fragments/os/macos.md
@@ -1,0 +1,3 @@
+- Assume macOS shell environment (BSD userland differences may apply).
+- Avoid Linux-only flags unless verified on macOS equivalents.
+- Quote paths with spaces and favor absolute paths in shell commands.

--- a/pi/agent/system-fragments/os/windows.md
+++ b/pi/agent/system-fragments/os/windows.md
@@ -1,0 +1,3 @@
+- Assume Windows path and shell differences; avoid Unix-only assumptions.
+- Use platform-appropriate path handling and quoting.
+- Verify command compatibility before suggesting shell sequences.

--- a/pi/agent/system-fragments/repo/worktree.md
+++ b/pi/agent/system-fragments/repo/worktree.md
@@ -1,0 +1,4 @@
+- Respect git worktree conventions.
+- Avoid making feature changes in the main worktree unless explicitly requested.
+- Keep branch/worktree context explicit before staging, committing, rebasing, or pushing.
+- For git operations, delegate to the git-ops subagent.


### PR DESCRIPTION
## Summary
- Phase 1 (`85af614`): Added runtime prompt composer and fragment packs.
- Phase 2 (`150c694`): Added runtime reminder engine extension.
- Phase 3 (`890b5ff`): Added quick commit/PR/security review prompt templates.
- Phase 4 (`96a7b95`): Added `/prompt-debug` and hardened planning subagents with read-only constraints plus critical-files output requirements.

## Smoke test notes
- ✅ RPC `get_state` succeeded with `PI_CODING_AGENT_DIR` pointing at this worktree's `pi/agent`.
- ✅ `/prompt-debug` extension command executed successfully in RPC mode.

## Verification checklist
- [x] Branch `feat/pi-prompt-phases` pushed to `origin` with upstream tracking.
- [x] PR targets base branch `next`.
- [x] Included summary for all 4 phase commits.
- [x] Included smoke test validation notes for RPC mode.